### PR TITLE
build(dependabot): change prefix to `fix` and set-up automerge

### DIFF
--- a/.dependabot/config.yaml
+++ b/.dependabot/config.yaml
@@ -5,7 +5,7 @@ update_configs:
     update_schedule: "live"
     automerged_updates:
       - match:
-          dependency_type: "all"
+          dependency_name: "HoneybeeSchema"
           update_type: "all"
     commit_message:
       prefix: "fix"

--- a/.dependabot/config.yaml
+++ b/.dependabot/config.yaml
@@ -1,0 +1,12 @@
+version: 1
+update_configs:
+  - package_manager: "dotnet:nuget"
+    directory: "/"
+    update_schedule: "live"
+    automerged_updates:
+      - match:
+          dependency_type: "all"
+          update_type: "all"
+    commit_message:
+      prefix: "fix"
+      include_scope: true


### PR DESCRIPTION
This should resolve the issue with `chore` prefix and also automerge the PR after passing the tests.

cc: @ksobon