### PR TITLE
feat: update HoneybeeSchema package and fix Plastic modifier handling

### DIFF
--- a/src/Honeybee.UI/CommonSettings.csproj
+++ b/src/Honeybee.UI/CommonSettings.csproj
@@ -8,7 +8,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="LBT.Newtonsoft.Json" Version="13.0.3.2" />
-		<PackageReference Include="HoneybeeSchema" Version="1.5901.5" />
+		<PackageReference Include="HoneybeeSchema" Version="2.5.1" />
 		<PackageReference Include="UnitsNet" Version="5.50.0" />
 	</ItemGroup>
 </Project>

--- a/src/Honeybee.UI/Dialog/DialogHelper.cs
+++ b/src/Honeybee.UI/Dialog/DialogHelper.cs
@@ -163,9 +163,6 @@ namespace Honeybee.UI
             HoneybeeSchema.Radiance.IModifier dialog_rc = null;
             switch (dup)
             {
-                case Plastic obj:
-                    dialog_rc = new Dialog_Modifier<Plastic>(obj, locked).ShowModal(parent);
-                    break;
                 case Glass obj:
                     dialog_rc = new Dialog_Modifier<Glass>(obj, locked).ShowModal(parent);
                     break;
@@ -186,6 +183,9 @@ namespace Honeybee.UI
                     break;
                 case BSDF obj:
                     dialog_rc = new Dialog_Modifier<BSDF>(obj, locked).ShowModal(parent);
+                    break;
+                case Plastic obj:
+                    dialog_rc = new Dialog_Modifier<Plastic>(obj, locked).ShowModal(parent);
                     break;
                 default:
                     break;

--- a/src/Honeybee.UI/ViewModel/ModifierManagerViewModel.cs
+++ b/src/Honeybee.UI/ViewModel/ModifierManagerViewModel.cs
@@ -189,9 +189,6 @@ namespace Honeybee.UI
             dup.DisplayName = name;
             switch (dup)
             {
-                case Plastic obj:
-                    AddPlasticCommand.Execute(obj);
-                    break;
                 case Glass obj:
                     AddGlassCommand.Execute(obj);
                     break;
@@ -212,6 +209,9 @@ namespace Honeybee.UI
                     break;
                 case BSDF obj:
                     AddBSDFCommand.Execute(obj);
+                    break;
+                case Plastic obj:
+                    AddPlasticCommand.Execute(obj);
                     break;
                 default:
                     break;


### PR DESCRIPTION
- Update HoneybeeSchema package from version 1.5901.5 to 2.5.1
- Move Plastic modifier case statement from beginning to end of switch blocks in DialogHelper.cs and ModifierManagerViewModel.cs
- This ensures proper handling of Plastic modifiers in the UI dialogs and view model operations